### PR TITLE
Add influencer connection feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Chrome extension that automatically finds posts in your LinkedIn feed, generat
 - 📊 **Real-time Analytics**: Live statistics for posts found, liked, and commented
 - 💾 **Smart Settings**: Persistent configuration with automatic saving
 - 🎲 **Randomized Delays**: Custom delay ranges for natural interaction patterns
+- 🔗 **Influencer Connections**: Searches for top influencers and sends connection requests to the top 10
 
 ## Installation
 

--- a/popup.html
+++ b/popup.html
@@ -105,6 +105,10 @@
         <span class="btn-icon">▶</span>
         Start Engagement
       </button>
+      <button id="connectInfluencers" class="btn btn-primary">
+        <span class="btn-icon">🔗</span>
+        Connect Influencers
+      </button>
       <button id="stopBot" class="btn btn-stop" disabled>
         <span class="btn-icon">⏹</span>
         Stop


### PR DESCRIPTION
## Summary
- add new popup option to connect with top influencers
- implement content script logic to select top reacted posts and send up to 10 connection requests
- document influencer connection capability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2eddd97e88323884383b4f974314c